### PR TITLE
Fire event on window and not document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ In order for WebView's javascript communicates to React-Native, you have to add 
         if (window.WebViewJavascriptBridge) {
             callback(WebViewJavascriptBridge)
         } else {
-            document.addEventListener('WebViewJavascriptBridgeReady', function() {
+            window.addEventListener('WebViewJavascriptBridgeReady', function() {
                 callback(WebViewJavascriptBridge);
             }, false)
         }

--- a/WebViewBridge/WebViewJavascriptBridge.js.txt
+++ b/WebViewBridge/WebViewJavascriptBridge.js.txt
@@ -108,10 +108,6 @@
 		_handleMessageFromObjC: _handleMessageFromObjC
 	}
 
-	var doc = document
-	_createQueueReadyIframe(doc)
-	var readyEvent = doc.createEvent('Events')
-	readyEvent.initEvent('WebViewJavascriptBridgeReady')
-	readyEvent.bridge = WebViewJavascriptBridge
-	doc.dispatchEvent(readyEvent)
+	_createQueueReadyIframe(document)
+	window.dispatchEvent(new CustomEvent('WebViewJavascriptBridgeReady'));
 })();

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "peerDependencies": {
-    "react-native": ">= 0.4 || 0.5.0-rc1 || 0.6.0-rc"
+    "react-native": "^0.6.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
I assume this is needed in case you are loading a page which is slow to load over the network. In my case I was not receiving events on the document object. This works, though I'm not entirely sure why.