### PR TITLE
Use passed webViewBridge in callback instead of global

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ const injectScript = `
   }
 
   webViewBridgeReady(function (webViewBridge) {
-    WebViewBridge.onMessage = function (message) {
+    webViewBridge.onMessage = function (message) {
       alert('got a message from Native: ' + message);
 
-      WebViewBridge.send("message from webview");
+      webViewBridge.send("message from webview");
     };
   });
 `;


### PR DESCRIPTION
I think in the example in README file you meant to use the `webViewBridge` instance passed to the callback instead of global `WebViewBridge`.