### PR TITLE
Proxy WebView proptypes to simplify

### DIFF
--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -111,19 +111,11 @@ var WebViewBridge = React.createClass({
       <RCTWebViewBridge
         ref={RCT_WEBVIEWBRIDGE_REF}
         key="webViewKey"
+        {...this.props}
         style={webViewStyles}
-        url={this.props.url}
-        html={this.props.html}
-        injectedJavaScript={this.props.injectedJavaScript}
-        userAgent={this.props.userAgent}
-        javaScriptEnabled={javaScriptEnabled}
-        domStorageEnabled={domStorageEnabled}
-        contentInset={this.props.contentInset}
-        automaticallyAdjustContentInsets={this.props.automaticallyAdjustContentInsets}
         onLoadingStart={this.onLoadingStart}
         onLoadingFinish={this.onLoadingFinish}
         onLoadingError={this.onLoadingError}
-        testID={this.props.testID}
       />;
 
     return (

--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -25,6 +25,7 @@ var {
   StyleSheet,
   Text,
   View,
+  WebView,
   requireNativeComponent,
   PropTypes,
   DeviceEventEmitter,
@@ -47,48 +48,7 @@ var WebViewBridgeState = keyMirror({
 var WebViewBridge = React.createClass({
 
   propTypes: {
-    ...View.propTypes,
-    renderError: PropTypes.func,
-    renderLoading: PropTypes.func,
-    onLoad: PropTypes.func,
-    onLoadEnd: PropTypes.func,
-    onLoadStart: PropTypes.func,
-    onError: PropTypes.func,
-    url: PropTypes.string,
-    html: PropTypes.string,
-    automaticallyAdjustContentInsets: PropTypes.bool,
-    contentInset: EdgeInsetsPropType,
-    onNavigationStateChange: PropTypes.func,
-    startInLoadingState: PropTypes.bool, // force WebView to show loadingView on first load
-    style: View.propTypes.style,
-
-    /**
-     * Used on Android only, JS is enabled by default for WebView on iOS
-     * @platform android
-     */
-    javaScriptEnabled: PropTypes.bool,
-
-    /**
-     * Used on Android only, controls whether DOM Storage is enabled or not
-     * @platform android
-     */
-    domStorageEnabled: PropTypes.bool,
-
-    /**
-     * Sets the JS to be injected when the webpage loads.
-     */
-    injectedJavaScript: PropTypes.string,
-
-    /**
-     * Sets the user-agent for this WebView. The user-agent can also be set in native using
-     * WebViewConfig. This prop will overwrite that config.
-     */
-    userAgent: PropTypes.string,
-
-    /**
-     * Used to locate this view in end-to-end tests.
-     */
-    testID: PropTypes.string,
+    ...WebView.propTypes,
 
     /**
      * Will be called once the message is being sent from webview

--- a/webview-bridge/index.ios.js
+++ b/webview-bridge/index.ios.js
@@ -24,6 +24,7 @@ var {
   StyleSheet,
   Text,
   View,
+  WebView,
   requireNativeComponent,
   PropTypes,
   UIManager,
@@ -94,87 +95,7 @@ var WebViewBridge = React.createClass({
   },
 
   propTypes: {
-    ...View.propTypes,
-    url: PropTypes.string,
-    html: PropTypes.string,
-    /**
-     * Function that returns a view to show if there's an error.
-     */
-    renderError: PropTypes.func, // view to show if there's an error
-    /**
-     * Function that returns a loading indicator.
-     */
-    renderLoading: PropTypes.func,
-    /**
-     * Invoked when load finish
-     */
-    onLoad: PropTypes.func,
-    /**
-     * Invoked when load either succeeds or fails
-     */
-    onLoadEnd: PropTypes.func,
-    /**
-     * Invoked on load start
-     */
-    onLoadStart: PropTypes.func,
-    /**
-     * Invoked when load fails
-     */
-    onError: PropTypes.func,
-    /**
-     * @platform ios
-     */
-    bounces: PropTypes.bool,
-    /**
-     * @platform ios
-     */
-    scrollEnabled: PropTypes.bool,
-    automaticallyAdjustContentInsets: PropTypes.bool,
-    contentInset: EdgeInsetsPropType,
-    onNavigationStateChange: PropTypes.func,
-    startInLoadingState: PropTypes.bool, // force WebView to show loadingView on first load
-    style: View.propTypes.style,
-
-    /**
-     * Used on Android only, JS is enabled by default for WebView on iOS
-     * @platform android
-     */
-    javaScriptEnabled: PropTypes.bool,
-
-    /**
-     * Used on Android only, controls whether DOM Storage is enabled or not
-     * @platform android
-     */
-    domStorageEnabled: PropTypes.bool,
-
-    /**
-     * Sets the JS to be injected when the webpage loads.
-     */
-    injectedJavaScript: PropTypes.string,
-
-    /**
-     * Sets whether the webpage scales to fit the view and the user can change the scale.
-     * @platform ios
-     */
-    scalesPageToFit: PropTypes.bool,
-
-    /**
-     * Allows custom handling of any webview requests by a JS handler. Return true
-     * or false from this method to continue loading the request.
-     * @platform ios
-     */
-    onShouldStartLoadWithRequest: PropTypes.func,
-
-    /**
-     * Determines whether HTML5 videos play inline or use the native full-screen
-     * controller.
-     * default value `false`
-     * **NOTE** : "In order for video to play inline, not only does this
-     * property need to be set to true, but the video element in the HTML
-     * document must also include the webkit-playsinline attribute."
-     * @platform ios
-     */
-    allowsInlineMediaPlayback: PropTypes.bool,
+    ...WebView.propTypes,
 
     /**
      * Will be called once the message is being sent from webview


### PR DESCRIPTION
Hi Ali,

First, thanks for releasing rn-webview-bridge, it's what we we were looking for.

RN changes proptypes in version 0.20 and currently using WebViewBridge with this version raises yellow warnings and doesn't work due to the appearance of `src` in proptypes, which is not . 

This is only the first part of a patch. If you agree with it, when you send the properties to `RCTWebViewBridge` can be simplified too, and there would be no need to do warn about `javaScriptEnabledAndroid` because RN does it for you. I can seen that part too if you wish.

Let me know what you think. BTW, your Android support is not working for us with RN0.19, because I believe something is broken in official webview for Android in this version, here is my report to the RN official issue:
https://github.com/facebook/react-native/issues/5211

I changed to v0.20 to see if it was working, and although now the url is rendered, the injected javascript only works in iOS:
https://github.com/facebook/react-native/issues/5940

So I couldn't test your Android feature, however I've read the code and your extending of RN official WebView in native code is beautiful.

Thanks, cheers,
Miguel