### PR TITLE
Fix for Passing `require('<SomeLocalURI>')` to .source, results in “E…

### DIFF
--- a/examples/SampleRN20/app.js
+++ b/examples/SampleRN20/app.js
@@ -44,14 +44,29 @@ var Sample2 = React.createClass({
   },
   render: function() {
     return (
+      <View style={styles.container}>
       <WebViewBridge
         ref="webviewbridge"
         onBridgeMessage={this.onBridgeMessage}
         javaScriptEnabled={true}
         injectedJavaScript={injectScript}
         source={{uri: "https://google.com"}}/>
+        <WebViewBridge
+        ref="webviewbridge"
+        onBridgeMessage={this.onBridgeMessage}
+        javaScriptEnabled={true}
+        injectedJavaScript={injectScript}
+        source={require('./test.html')}/>
+        </View>
     );
   }
 });
 
 module.exports = Sample2;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1
+  }
+});
+

--- a/examples/SampleRN20/app.js
+++ b/examples/SampleRN20/app.js
@@ -52,7 +52,7 @@ var Sample2 = React.createClass({
         injectedJavaScript={injectScript}
         source={{uri: "https://google.com"}}/>
         <WebViewBridge
-        ref="webviewbridge"
+        ref="webviewbridge2"
         onBridgeMessage={this.onBridgeMessage}
         javaScriptEnabled={true}
         injectedJavaScript={injectScript}

--- a/examples/SampleRN20/test.html
+++ b/examples/SampleRN20/test.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+</head>
+<body>
+Hello test html
+</body>
+</html>

--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -113,13 +113,7 @@ var WebViewBridge = React.createClass({
     }
 
     let props = {...this.props};  
-    var source = props.source || {};
-    if(this.props.html) {
-      source.html = this.props.html;
-    } else if(this.props.url) {
-      source.uri = this.props.url;
-    }
-    props.source = resolveAssetSource(source);
+    props.source = resolveAssetSource(props.source);
 
     var webView =
       <RCTWebViewBridge

--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -17,6 +17,8 @@ var React = require('react-native');
 var invariant = require('invariant');
 var keyMirror = require('keymirror');
 var merge = require('merge');
+var resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource.js');
+
 
 var {
   ReactNativeViewAttributes,
@@ -110,11 +112,20 @@ var WebViewBridge = React.createClass({
       domStorageEnabled = this.props.domStorageEnabledAndroid;
     }
 
+    let props = {...this.props};  
+    var source = props.source || {};
+    if(this.props.html) {
+      source.html = this.props.html;
+    } else if(this.props.url) {
+      source.uri = this.props.url;
+    }
+    props.source = resolveAssetSource(source);
+
     var webView =
       <RCTWebViewBridge
         ref={RCT_WEBVIEWBRIDGE_REF}
         key="webViewKey"
-        {...this.props}
+        {...props}
         style={webViewStyles}
         onLoadingStart={this.onLoadingStart}
         onLoadingFinish={this.onLoadingFinish}

--- a/webview-bridge/index.ios.js
+++ b/webview-bridge/index.ios.js
@@ -17,6 +17,7 @@
 var React = require('react-native');
 var invariant = require('invariant');
 var keyMirror = require('keymirror');
+var resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource.js');
 
 var {
   ActivityIndicatorIOS,
@@ -174,9 +175,18 @@ var WebViewBridge = React.createClass({
       }
     };
 
-    const props = {...this.props};
+    let props = {...this.props};
     delete props.onBridgeMessage;
     delete props.onShouldStartLoadWithRequest;
+
+    var source = props.source || {};
+    if(this.props.html) {
+      source.html = this.props.html;
+    } else if(this.props.url) {
+      source.uri = this.props.url;
+    }
+    props.source = resolveAssetSource(source);
+
 
     var webView =
       <RCTWebViewBridge

--- a/webview-bridge/index.ios.js
+++ b/webview-bridge/index.ios.js
@@ -179,13 +179,7 @@ var WebViewBridge = React.createClass({
     delete props.onBridgeMessage;
     delete props.onShouldStartLoadWithRequest;
 
-    var source = props.source || {};
-    if(this.props.html) {
-      source.html = this.props.html;
-    } else if(this.props.url) {
-      source.uri = this.props.url;
-    }
-    props.source = resolveAssetSource(source);
+    props.source = resolveAssetSource(props.source);
 
 
     var webView =


### PR DESCRIPTION
#61 …rror while updating property ‘source’ of a view managed by RCTWebViewBridge”. #61