### PR TITLE
Fix Android version

### DIFF
--- a/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgeManager.java
+++ b/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgeManager.java
@@ -72,6 +72,7 @@ public class WebViewBridgeManager extends ReactWebViewManager {
     if (!initializedBridge) {
       root.addJavascriptInterface(new JavascriptBridge((ReactContext)root.getContext()), "WebViewBridgeAndroid");
       initializedBridge = true;
+      root.reload();
     }
 
     //this code needs to be executed everytime a url changes.

--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -120,6 +120,7 @@ var WebViewBridge = React.createClass({
         ref={RCT_WEBVIEWBRIDGE_REF}
         key="webViewKey"
         {...props}
+        source={source}
         style={webViewStyles}
         onLoadingStart={this.onLoadingStart}
         onLoadingFinish={this.onLoadingFinish}


### PR DESCRIPTION
Hi,

This PR fixes 2 problems encountered on Android: 
- A bug introduced [here](https://github.com/alinz/react-native-webview-bridge/commit/c539435ebd88361b6b576002a0763863d06df535#diff-23716cafc3c98d6a84b31bd79e57b607R115) where the `source` prop wasn't set on Android.
- Reloads the webview once the javascript has been injected, as it needs to be done to be able to use the newly created javascript interface. See [`addJavascriptInterface(Object object, String name)`](http://developer.android.com/intl/es/reference/android/webkit/WebView.html#addJavascriptInterface(java.lang.Object, java.lang.String)):

>   Note that injected objects will not appear in JavaScript until the page is next (re)loaded.

Using that it works perfectly for us, thanks for the project!

Let me know if I can do something else.