### PR TITLE
Do not strip Javascript bridge method on proguard run

### DIFF
--- a/android/src/main/java/com/github/alinz/reactnativewebviewbridge/JavascriptBridge.java
+++ b/android/src/main/java/com/github/alinz/reactnativewebviewbridge/JavascriptBridge.java
@@ -2,6 +2,7 @@ package com.github.alinz.reactnativewebviewbridge;
 
 import android.webkit.JavascriptInterface;
 
+import com.facebook.common.internal.DoNotStrip;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
@@ -14,6 +15,7 @@ class JavascriptBridge {
     this.context = context;
   }
 
+  @DoNotStrip
   @JavascriptInterface
   public void send(String message) {
     WritableMap params = Arguments.createMap();


### PR DESCRIPTION
This module wasn't working anymore with Proguard enabled because Proguard was striping away the `send` method in `JavascriptBridge.java`.

This PR fixes that by using the [`DoNotStrip`](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/proguard/annotations/DoNotStrip.java) annotation from React Native since it is already configured to be used in the default `proguard-rules.pro`.