### PR TITLE
Fix the bug of stopping working after first time at Android platform

### DIFF
--- a/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgeManager.java
+++ b/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgeManager.java
@@ -4,8 +4,8 @@ import android.webkit.WebView;
 
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.views.webview.ReactWebViewManager;
-import com.facebook.react.views.webview.WebViewConfig;
 
 import java.util.Map;
 
@@ -16,18 +16,6 @@ public class WebViewBridgeManager extends ReactWebViewManager {
 
   public static final int COMMAND_INJECT_BRIDGE_SCRIPT = 100;
   public static final int COMMAND_SEND_TO_BRIDGE = 101;
-
-  private boolean initializedBridge;
-
-  public WebViewBridgeManager() {
-    super();
-    initializedBridge = false;
-  }
-
-  public WebViewBridgeManager(WebViewConfig webViewConfig) {
-    super(webViewConfig);
-    initializedBridge = false;
-  }
 
   @Override
   public String getName() {
@@ -66,14 +54,20 @@ public class WebViewBridgeManager extends ReactWebViewManager {
     WebViewBridgeManager.evaluateJavascript(root, script);
   }
 
-  private void injectBridgeScript(WebView root) {
-    //this code needs to be called once per context
-    if (!initializedBridge) {
-      root.addJavascriptInterface(new JavascriptBridge((ReactContext) root.getContext()), "WebViewBridgeAndroid");
-      initializedBridge = true;
-      root.reload();
-    }
+  @Override
+  protected WebView createViewInstance(ThemedReactContext reactContext) {
+    WebView root = super.createViewInstance(reactContext);
+    root.addJavascriptInterface(new JavascriptBridge((ReactContext) root.getContext()), "WebViewBridgeAndroid");
+    return root;
+  }
 
+  @Override
+  public void onDropViewInstance(WebView root) {
+    root.removeJavascriptInterface("WebViewBridgeAndroid");
+    super.onDropViewInstance(root);
+  }
+
+  private void injectBridgeScript(WebView root) {
     // this code needs to be executed everytime a url changes.
     WebViewBridgeManager.evaluateJavascript(root, ""
             + "(function() {"

--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -66,7 +66,7 @@ var WebViewBridge = React.createClass({
   },
 
   componentWillMount: function() {
-    DeviceEventEmitter.addListener("webViewBridgeMessage", (body) => {
+    this.emmiter = DeviceEventEmitter.addListener("webViewBridgeMessage", (body) => {
       const { onBridgeMessage } = this.props;
       const message = body.message;
       if (onBridgeMessage) {
@@ -77,6 +77,10 @@ var WebViewBridge = React.createClass({
     if (this.props.startInLoadingState) {
       this.setState({viewState: WebViewBridgeState.LOADING});
     }
+  },
+
+  componentWillUnmount: function() {
+    this.emmiter.remove();
   },
 
   render: function() {


### PR DESCRIPTION
Fix the bug of stopping working after first time at Android platform.

Resolve   issue #64 and issue #77; and, contain the changes in PR #81(This PR is great, but has conflicts with the master branch). 

It works fine in my project.

<br />
##### Changes:
- Add `componentWillUnmount` method into `index.android.js`, aimming to remove `webViewBridgeMessage` listener while component will unmount.
- Remove `initializedBridge` variable in `WebViewBridgeManager.java`; and, add `WebViewBridgeManager` and `WebViewBridgeManager` methods to handle listener removing that refered before.