### PR TITLE
Undo assumption that ViewManager will only handle a single WebView ever

### DIFF
--- a/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgeManager.java
+++ b/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgeManager.java
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.views.webview.ReactWebViewManager;
 import com.facebook.react.views.webview.WebViewConfig;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -17,16 +18,14 @@ public class WebViewBridgeManager extends ReactWebViewManager {
   public static final int COMMAND_INJECT_BRIDGE_SCRIPT = 100;
   public static final int COMMAND_SEND_TO_BRIDGE = 101;
 
-  private boolean initializedBridge;
+  private Map<WebView, Boolean> initializedBridges = new HashMap<>();
 
   public WebViewBridgeManager() {
     super();
-    initializedBridge = false;
   }
 
   public WebViewBridgeManager(WebViewConfig webViewConfig) {
     super(webViewConfig);
-    initializedBridge = false;
   }
 
   @Override
@@ -37,6 +36,7 @@ public class WebViewBridgeManager extends ReactWebViewManager {
   @Override
   public @Nullable Map<String, Integer> getCommandsMap() {
     Map<String, Integer> commandsMap = super.getCommandsMap();
+    if (commandsMap == null) commandsMap = new HashMap<>();   // Fix potential NPE
 
     commandsMap.put("injectBridgeScript", COMMAND_INJECT_BRIDGE_SCRIPT);
     commandsMap.put("sendToBridge", COMMAND_SEND_TO_BRIDGE);
@@ -68,9 +68,9 @@ public class WebViewBridgeManager extends ReactWebViewManager {
 
   private void injectBridgeScript(WebView root) {
     //this code needs to be called once per context
-    if (!initializedBridge) {
+    if (initializedBridges.get(root) == null || !initializedBridges.get(root)) {
       root.addJavascriptInterface(new JavascriptBridge((ReactContext) root.getContext()), "WebViewBridgeAndroid");
-      initializedBridge = true;
+      initializedBridges.put(root, true);
       root.reload();
     }
 


### PR DESCRIPTION
See issue #105 for the specifics, basically `WebViewBridgeManager` assumed only one `WebView`-instance would exist in it's own lifecycle, which is apparently not quite true.

Oh, and I fixed a potential nullpointerexception on the way, as Android Studio was nagging me about it. I assumed returning always returning a filled `commandMap` was prefered over returning null when the parent returns null.

I wrote the contents of this PR in work time at [Athom](https://www.athom.com/en/), a Netherlands-based startup.