### PR TITLE
Proguard configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ compile project(':react-native-webview-bridge')
 
 5. run `react-native run-android` to see if everything is compilable.
 
+## Proguard configuration
+
+If proguard (minification/obfuscation) is enabled in your project, add these rules to your `proguard-rules.pro`:
+
+```
+
+# react-native-webview-bridge
+-keepattributes JavascriptInterface
+-keep class com.github.alinz.reactnativewebviewbridge.**
+-keepclassmembers class ** {
+    @android.webkit.JavascriptInterface <methods>;
+}
+```
+
 ## Usage
 
 just import the module with one of your choices way:


### PR DESCRIPTION
If proguard is enabled, `JavascriptBridge#send()` gets removed in minification since it is only ever called from within the injected javascript in `WebViewBridgeManager` and proguard doesn't know that.
Must add specific proguard limitation to fix.
