### PR TITLE
iOS: Escape singlequotes or messages containing ' will fail

### DIFF
--- a/ios/RCTWebViewBridge.m
+++ b/ios/RCTWebViewBridge.m
@@ -97,8 +97,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
       }
     }());
   );
+    
+  // Escape singlequotes or messages containing ' will fail
+  NSString *quotedMessage = [message stringByReplacingOccurrencesOfString:@"'" withString:@"\\'"];
 
-  NSString *command = [NSString stringWithFormat: format, message];
+  NSString *command = [NSString stringWithFormat: format, quotedMessage];
   [_webView stringByEvaluatingJavaScriptFromString:command];
 }
 


### PR DESCRIPTION
RCTWebViewBridge.m has a classic 'SQL Injection Attack' issue.

The use of "'%@'" - intending to wrap the string in single quotes, will fail if the string itself contains a single quote.  

We discovered this when we noted that JSON payloads containing strings with ' characters were not appearing in the WebView as expected.

This PR simply escapes ' characters before formatting into the JavaScript string.
