### PR TITLE
IOS and Android updates and fixes for RN 0.33

### DIFF
--- a/android/src/main/java/com/github/alinz/reactnativewebviewbridge/JavascriptBridge.java
+++ b/android/src/main/java/com/github/alinz/reactnativewebviewbridge/JavascriptBridge.java
@@ -1,24 +1,29 @@
 package com.github.alinz.reactnativewebviewbridge;
 
 import android.webkit.JavascriptInterface;
+import android.webkit.WebView;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 class JavascriptBridge {
-  private ReactContext context;
+    private WebView webView;
 
-  public JavascriptBridge(ReactContext context) {
-    this.context = context;
-  }
+    public JavascriptBridge(WebView webView) {
+        this.webView = webView;
+    }
 
-  @JavascriptInterface
-  public void send(String message) {
-    WritableMap params = Arguments.createMap();
-    params.putString("message", message);
-    context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-            .emit("webViewBridgeMessage", params);
-  }
+    @JavascriptInterface
+    public void send(String message) {
+        WritableMap event = Arguments.createMap();
+        event.putString("message", message);
+        ReactContext reactContext = (ReactContext) this.webView.getContext();
+        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
+                this.webView.getId(),
+                "topChange",
+                event);
+    }
 }

--- a/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgeManager.java
+++ b/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgeManager.java
@@ -2,98 +2,72 @@ package com.github.alinz.reactnativewebviewbridge;
 
 import android.webkit.WebView;
 
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.views.webview.ReactWebViewManager;
-import com.facebook.react.views.webview.WebViewConfig;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 import javax.annotation.Nullable;
 
 public class WebViewBridgeManager extends ReactWebViewManager {
-  private static final String REACT_CLASS = "RCTWebViewBridge";
+    private static final String REACT_CLASS = "RCTWebViewBridge";
 
-  public static final int COMMAND_INJECT_BRIDGE_SCRIPT = 100;
-  public static final int COMMAND_SEND_TO_BRIDGE = 101;
+    public static final int COMMAND_SEND_TO_BRIDGE = 101;
 
-  private boolean initializedBridge;
-
-  public WebViewBridgeManager() {
-    super();
-    initializedBridge = false;
-  }
-
-  public WebViewBridgeManager(WebViewConfig webViewConfig) {
-    super(webViewConfig);
-    initializedBridge = false;
-  }
-
-  @Override
-  public String getName() {
-    return REACT_CLASS;
-  }
-
-  @Override
-  public @Nullable Map<String, Integer> getCommandsMap() {
-    Map<String, Integer> commandsMap = super.getCommandsMap();
-
-    commandsMap.put("injectBridgeScript", COMMAND_INJECT_BRIDGE_SCRIPT);
-    commandsMap.put("sendToBridge", COMMAND_SEND_TO_BRIDGE);
-
-    return commandsMap;
-  }
-
-  @Override
-  public void receiveCommand(WebView root, int commandId, @Nullable ReadableArray args) {
-    super.receiveCommand(root, commandId, args);
-
-    switch (commandId) {
-      case COMMAND_INJECT_BRIDGE_SCRIPT:
-        injectBridgeScript(root);
-        break;
-      case COMMAND_SEND_TO_BRIDGE:
-        sendToBridge(root, args.getString(0));
-        break;
-      default:
-        //do nothing!!!!
-    }
-  }
-
-  private void sendToBridge(WebView root, String message) {
-    //root.loadUrl("javascript:(function() {\n" + script + ";\n})();");
-    String script = "WebViewBridge.onMessage('" + message + "');";
-    WebViewBridgeManager.evaluateJavascript(root, script);
-  }
-
-  private void injectBridgeScript(WebView root) {
-    //this code needs to be called once per context
-    if (!initializedBridge) {
-      root.addJavascriptInterface(new JavascriptBridge((ReactContext) root.getContext()), "WebViewBridgeAndroid");
-      initializedBridge = true;
-      root.reload();
+    @Override
+    public String getName() {
+        return REACT_CLASS;
     }
 
-    // this code needs to be executed everytime a url changes.
-    WebViewBridgeManager.evaluateJavascript(root, ""
-            + "(function() {"
-            + "if (window.WebViewBridge) return;"
-            + "var customEvent = document.createEvent('Event');"
-            + "var WebViewBridge = {"
-              + "send: function(message) { WebViewBridgeAndroid.send(message); },"
-              + "onMessage: function() {}"
-            + "};"
-            + "window.WebViewBridge = WebViewBridge;"
-            + "customEvent.initEvent('WebViewBridge', true, true);"
-            + "document.dispatchEvent(customEvent);"
-            + "}());");
-  }
+    private ArrayList<Integer> webViewsWithBridgeScript = new ArrayList<Integer>();
 
-  static private void evaluateJavascript(WebView root, String javascript) {
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
-      root.evaluateJavascript(javascript, null);
-    } else {
-      root.loadUrl("javascript:" + javascript);
+    @Override
+    public
+    @Nullable
+    Map<String, Integer> getCommandsMap() {
+        Map<String, Integer> commandsMap = super.getCommandsMap();
+
+        commandsMap.put("sendToBridge", COMMAND_SEND_TO_BRIDGE);
+
+        return commandsMap;
     }
-  }
+
+    @Override
+    protected WebView createViewInstance(ThemedReactContext reactContext) {
+        WebView root = super.createViewInstance(reactContext);
+        root.getSettings().setAllowFileAccessFromFileURLs(true);
+        root.getSettings().setAllowUniversalAccessFromFileURLs(true);
+        root.addJavascriptInterface(new JavascriptBridge(root), "WebViewBridge");
+        return root;
+    }
+
+    @Override
+    public void receiveCommand(WebView root, int commandId, @Nullable ReadableArray args) {
+        super.receiveCommand(root, commandId, args);
+        // if (true) return;
+
+        switch (commandId) {
+            case COMMAND_SEND_TO_BRIDGE:
+                sendToBridge(root, args.getString(0));
+                break;
+            default:
+                //do nothing!!!!
+        }
+    }
+
+    private void sendToBridge(WebView root, String message) {
+        //root.loadUrl("javascript:(function() {\n" + script + ";\n})();");
+        String script = "WebViewBridge.onMessage('" + message + "');";
+        WebViewBridgeManager.evaluateJavascript(root, script);
+    }
+
+    static private void evaluateJavascript(WebView root, String javascript) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
+            root.evaluateJavascript(javascript, null);
+        } else {
+            root.loadUrl("javascript:" + javascript);
+        }
+    }
 }

--- a/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgeManager.java
+++ b/android/src/main/java/com/github/alinz/reactnativewebviewbridge/WebViewBridgeManager.java
@@ -5,6 +5,7 @@ import android.webkit.WebView;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.views.webview.ReactWebViewManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -37,8 +38,6 @@ public class WebViewBridgeManager extends ReactWebViewManager {
     @Override
     protected WebView createViewInstance(ThemedReactContext reactContext) {
         WebView root = super.createViewInstance(reactContext);
-        root.getSettings().setAllowFileAccessFromFileURLs(true);
-        root.getSettings().setAllowUniversalAccessFromFileURLs(true);
         root.addJavascriptInterface(new JavascriptBridge(root), "WebViewBridge");
         return root;
     }
@@ -69,5 +68,15 @@ public class WebViewBridgeManager extends ReactWebViewManager {
         } else {
             root.loadUrl("javascript:" + javascript);
         }
+    }
+
+    @ReactProp(name = "allowFileAccessFromFileURLs")
+    public void setAllowFileAccessFromFileURLs(WebView root, boolean allows) {
+        root.getSettings().setAllowFileAccessFromFileURLs(allows);
+    }
+
+    @ReactProp(name = "allowUniversalAccessFromFileURLs")
+    public void setAllowUniversalAccessFromFileURLs(WebView root, boolean allows) {
+        root.getSettings().setAllowUniversalAccessFromFileURLs(allows);
     }
 }

--- a/ios/RCTWebViewBridge.m
+++ b/ios/RCTWebViewBridge.m
@@ -21,6 +21,7 @@
 #import "RCTUtils.h"
 #import "RCTView.h"
 #import "UIView+React.h"
+#import <objc/runtime.h>
 
 //This is a very elegent way of defining multiline string in objective-c.
 //source: http://stackoverflow.com/a/23387659/828487

--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -65,6 +65,7 @@ var WebViewBridge = React.createClass({
     };
   },
 
+  
   componentWillMount: function() {
     DeviceEventEmitter.addListener("webViewBridgeMessage", (body) => {
       const { onBridgeMessage } = this.props;
@@ -117,12 +118,14 @@ var WebViewBridge = React.createClass({
       <RCTWebViewBridge
         ref={RCT_WEBVIEWBRIDGE_REF}
         key="webViewKey"
+ 				javaScriptEnabled={true}
         {...props}
         source={resolveAssetSource(source)}
         style={webViewStyles}
         onLoadingStart={this.onLoadingStart}
         onLoadingFinish={this.onLoadingFinish}
         onLoadingError={this.onLoadingError}
+        onChange={this.onMessage}
       />;
 
     return (
@@ -131,6 +134,12 @@ var WebViewBridge = React.createClass({
         {otherView}
       </View>
     );
+  },
+
+  onMessage(event) {
+    if (this.props.onBridgeMessage != null && event.nativeEvent != null) {
+      this.props.onBridgeMessage(event.nativeEvent.message)
+    }
   },
 
   goForward: function() {
@@ -199,7 +208,6 @@ var WebViewBridge = React.createClass({
     var {onError, onLoadEnd} = this.props;
     onError && onError(event);
     onLoadEnd && onLoadEnd(event);
-    console.error('Encountered an error loading page', event.nativeEvent);
 
     this.setState({
       lastErrorEvent: event.nativeEvent,

--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -174,14 +174,6 @@ var WebViewBridge = React.createClass({
     );
   },
 
-  injectBridgeScript: function () {
-    UIManager.dispatchViewManagerCommand(
-      this.getWebViewBridgeHandle(),
-      UIManager.RCTWebViewBridge.Commands.injectBridgeScript,
-      null
-    );
-  },
-
   /**
    * We return an event with a bunch of fields including:
    *  url, title, loading, canGoBack, canGoForward
@@ -197,7 +189,6 @@ var WebViewBridge = React.createClass({
   },
 
   onLoadingStart: function(event) {
-    this.injectBridgeScript();
     var onLoadStart = this.props.onLoadStart;
     onLoadStart && onLoadStart(event);
     this.updateNavigationState(event);

--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -43,13 +43,15 @@ var WebViewBridgeState = keyMirror({
   ERROR: null,
 });
 
+var RCTWebViewBridge = requireNativeComponent('RCTWebViewBridge', WebViewBridge);
+
 /**
  * Renders a native WebView.
  */
 var WebViewBridge = React.createClass({
 
   propTypes: {
-    ...WebView.propTypes,
+    ...RCTWebViewBridge.propTypes,
 
     /**
      * Will be called once the message is being sent from webview
@@ -217,7 +219,6 @@ var WebViewBridge = React.createClass({
   },
 });
 
-var RCTWebViewBridge = requireNativeComponent('RCTWebViewBridge', WebViewBridge);
 
 var styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
Sharing some updates needed to use this in a project with RN 0.33.  Main issue I encountered was if multiple WebViewBridge components existed in Android, the webview-to-rnjs messages were broadcast to all WebViewBridge components instead of just the component containing the web view.

Updates include:
- Incorporated IOS fix from @JakeRawr
- Updated WebViewBridgeManager to use the JavascriptBridge class to make "WebViewBridge.send()" available to the web view instead of injecting script.
- Removed the "injectBridgeScript" command and instead overrode createViewInstance() to add JavascriptBridge immediately after web view creation
- Changed how JavascriptBridge dispatches messages to RN js (followed Facebook's example for a native UI component).  Messages now go to the instance vs a device-level event that goes to all instances,
- Added additional Android props (allowFileAccessFromFileURLs and allowUniversalAccessFromFileURLs) to allow file:// web view urls and ajax loading of file:// resources respectively