### PR TITLE
Add a prop for iOS to display the keyboard without user input

### DIFF
--- a/ios/RCTWebViewBridgeManager.m
+++ b/ios/RCTWebViewBridgeManager.m
@@ -50,6 +50,7 @@ RCT_EXPORT_VIEW_PROPERTY(onLoadingError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onShouldStartLoadWithRequest, RCTDirectEventBlock)
 RCT_REMAP_VIEW_PROPERTY(allowsInlineMediaPlayback, _webView.allowsInlineMediaPlayback, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onBridgeMessage, RCTDirectEventBlock)
+RCT_REMAP_VIEW_PROPERTY(keyboardDisplayRequiresUserAction, _webView.keyboardDisplayRequiresUserAction, BOOL)
 
 - (NSDictionary<NSString *, id> *)constantsToExport
 {

--- a/webview-bridge/index.ios.js
+++ b/webview-bridge/index.ios.js
@@ -105,6 +105,8 @@ var WebViewBridge = React.createClass({
     onBridgeMessage: PropTypes.func,
 
     hideKeyboardAccessoryView: PropTypes.bool,
+
+    keyboardDisplayRequiresUserAction: PropTypes.bool,
   },
 
   getInitialState: function() {


### PR DESCRIPTION
Resolves the request in https://github.com/alinz/react-native-webview-bridge/issues/120