### PR TITLE
Improve compatibility with IOS 8

### DIFF
--- a/ios/React-Native-Webview-Bridge.xcodeproj/project.pbxproj
+++ b/ios/React-Native-Webview-Bridge.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 					"$(SRCROOT)/../../../node_module/React/**",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -246,6 +247,7 @@
 					"$(SRCROOT)/../../../node_module/React/**",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
hi @alinz, proposing a change to the xcode build settings to set the IOS Deployment target to 8.0.  This aligns with the RN project template and the supported IOS versions in RN (8.0+).  The previous deployment target was 9.1, and I wanted to see if you had a reason for that value before changing.

Reason for change was apps using the webview bridge in IOS 8.x simulators in XCode 8 would hard crash with a `_objc_unsafeClaimAutoreleasedReturnValue` error.  Per [this SO post](http://stackoverflow.com/questions/39486064/xcode-8-ios-8-simulator-with-crash-dyld-lazy-symbol-binding-failed-symbol-n), this can happen if a sub-project has a deploy target higher than the parent project. 