### PR TITLE
Add support for stopLoading function in android

### DIFF
--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -168,6 +168,14 @@ var WebViewBridge = React.createClass({
     );
   },
 
+  stopLoading: function() {
+     UIManager.dispatchViewManagerCommand(
+      this.getWebViewBridgeHandle(),
+      UIManager.RCTWebViewBridge.Commands.stopLoading,
+      null
+    );
+  },
+
   sendToBridge: function (message: string) {
     UIManager.dispatchViewManagerCommand(
       this.getWebViewBridgeHandle(),


### PR DESCRIPTION
Add the method stopLoading, this is important because in android there is not implementation of **onShouldStartLoadWithRequest** and sometimes is necessary to void to load an specific url like when the url has  custom scheme.