### PR TITLE
Add https to README example to prevent NSURLError Domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ var Sample2 = React.createClass({
         ref="webviewbridge"
         onBridgeMessage={this.onBridgeMessage.bind(this)}
         injectedJavaScript={injectScript}
-        source={{uri: "http://google.com"}}/>
+        source={{uri: "https://google.com"}}/>
     );
   }
 });


### PR DESCRIPTION
Hi there, 

Just replacing http for https for others that might copy the README.md example

![captura de pantalla 2016-11-13 a las 23 50 06](https://cloud.githubusercontent.com/assets/3205919/20249931/776153c2-a9fc-11e6-924c-5fcf08f00551.png)

Great package by the way, cheers
