### PR TITLE
Fix IOS compile error for RN version > 0.40

### DIFF
--- a/ios/RCTWebViewBridge.h
+++ b/ios/RCTWebViewBridge.h
@@ -10,7 +10,16 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "RCTView.h"
+ /**
+  * Fix compile error for RN version > 0.40
+  */
+ #if __has_include(<React/RCTView.h>)
+ #import <React/RCTView.h>
+ #elif __has_include("RCTView.h")
+ #import "RCTView.h"
+ #else
+ #import "React/RCTView.h"
+ #endif
 
 @class RCTWebViewBridge;
 

--- a/ios/RCTWebViewBridge.m
+++ b/ios/RCTWebViewBridge.m
@@ -10,18 +10,36 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "RCTWebViewBridge.h"
+ #import "RCTWebViewBridge.h"
 
-#import <UIKit/UIKit.h>
+ #import <UIKit/UIKit.h>
 
-#import "RCTAutoInsetsProtocol.h"
-#import "RCTConvert.h"
-#import "RCTEventDispatcher.h"
-#import "RCTLog.h"
-#import "RCTUtils.h"
-#import "RCTView.h"
-#import "UIView+React.h"
-#import <objc/runtime.h>
+ #if __has_include(<React/RCTAutoInsetsProtocol.h>)
+ #import <React/RCTAutoInsetsProtocol.h>
+ #import <React/RCTConvert.h>
+ #import <React/RCTEventDispatcher.h>
+ #import <React/RCTLog.h>
+ #import <React/RCTUtils.h>
+ #import <React/RCTView.h>
+ #import <React/UIView+React.h>
+ #elif __has_include("RCTAutoInsetsProtocol.h")
+ #import "RCTAutoInsetsProtocol.h"
+ #import "RCTConvert.h"
+ #import "RCTEventDispatcher.h"
+ #import "RCTLog.h"
+ #import "RCTUtils.h"
+ #import "RCTView.h"
+ #import "UIView+React.h"
+ #else
+ #import "React/RCTAutoInsetsProtocol.h"
+ #import "React/RCTConvert.h"
+ #import "React/RCTEventDispatcher.h"
+ #import "React/RCTLog.h"
+ #import "React/RCTUtils.h"
+ #import "React/RCTView.h"
+ #import "React/UIView+React.h"
+ #endif
+ #import <objc/runtime.h>
 
 //This is a very elegent way of defining multiline string in objective-c.
 //source: http://stackoverflow.com/a/23387659/828487

--- a/ios/RCTWebViewBridgeManager.h
+++ b/ios/RCTWebViewBridgeManager.h
@@ -10,7 +10,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "RCTViewManager.h"
+ #if __has_include(<React/RCTViewManager.h>)
+ #import <React/RCTViewManager.h>
+ #elif __has_include("RCTViewManager.h")
+ #import "RCTViewManager.h"
+ #else
+ #import "React/RCTViewManager.h"
+ #endif
 
 @interface RCTWebViewBridgeManager : RCTViewManager
 

--- a/ios/RCTWebViewBridgeManager.m
+++ b/ios/RCTWebViewBridgeManager.m
@@ -10,12 +10,22 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "RCTWebViewBridgeManager.h"
+ #import "RCTWebViewBridge.h"
+ #import "RCTWebViewBridgeManager.h"
 
-#import "RCTBridge.h"
-#import "RCTUIManager.h"
-#import "RCTWebViewBridge.h"
-#import "UIView+React.h"
+ #if __has_include(<React/RCTBridge.h>)
+ #import <React/RCTBridge.h>
+ #import <React/RCTUIManager.h>
+ #import <React/UIView+React.h>
+ #elif __has_include("RCTBridge.h")
+ #import "RCTBridge.h"
+ #import "RCTUIManager.h"
+ #import "UIView+React.h"
+ #else
+ #import "React/RCTBridge.h"
+ #import "React/RCTUIManager.h"
+ #import "React/UIView+React.h"
+ #endif
 
 @interface RCTWebViewBridgeManager () <RCTWebViewBridgeDelegate>
 


### PR DESCRIPTION
Fix compile error for RN version > 0.40 caused by [this reason](https://github.com/facebook/react-native/releases/tag/v0.40.0). Like #202 , but check validity before using `#import <React/RCTView.h>`.
Thanks.