### PR TITLE
React native 0.6+ compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webview-bridge",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "description": "React Native WebView Javascript Bridge",
   "main": "webview-bridge",
   "directories": {
@@ -34,5 +34,8 @@
     "invariant": "^2.2.2",
     "keymirror": "0.1.1",
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "react-native-webview": "^7.5.2"   
   }
 }

--- a/react-native-webview-bridge.podspec
+++ b/react-native-webview-bridge.podspec
@@ -1,0 +1,21 @@
+require 'json'
+version = JSON.parse(File.read('package.json'))["version"]
+
+Pod::Spec.new do |s|
+
+  s.name            = "react-native-webview-bridge"
+  s.version         = version
+  s.homepage        = "https://github.com/alinz/react-native-webview-bridge"
+  s.summary         = "A webview bridge for react-native"
+  s.license         = "MIT"
+  s.author          = { "alinz" => "a.najafizadeh@gmail.com" }
+  s.ios.deployment_target = '9.0'
+  s.tvos.deployment_target = '9.0'
+  s.source          = { :git => "https://github.com/alinz/react-native-webview-bridge", :tag => "#{s.version}" }
+  s.source_files    = 'ios/*.{h,m}'
+  s.preserve_paths  = "**/*.js"
+  s.frameworks = 'UIKit', 'QuartzCore', 'Foundation'
+
+  s.dependency 'React'
+
+end

--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -70,7 +70,7 @@ var WebViewBridge = createReactClass({
   },
 
   
-  componentWillMount: function() {
+  componentDidMount: function() {
     DeviceEventEmitter.addListener("webViewBridgeMessage", (body) => {
       const { onBridgeMessage } = this.props;
       const message = body.message;

--- a/webview-bridge/index.android.js
+++ b/webview-bridge/index.android.js
@@ -21,6 +21,7 @@ var invariant = require('invariant');
 var keyMirror = require('keymirror');
 var resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource');
 
+var WebView = require('react-native-webview');
 var {
   ReactNativeViewAttributes,
   UIManager,
@@ -29,7 +30,6 @@ var {
   Text,
   View,
   ViewPropTypes,
-  WebView,
   requireNativeComponent,
   DeviceEventEmitter,
   NativeModules: {

--- a/webview-bridge/index.ios.js
+++ b/webview-bridge/index.ios.js
@@ -22,6 +22,7 @@ var invariant = require('invariant');
 var keyMirror = require('keymirror');
 var resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource');
 
+var WebView = require('react-native-webview');
 var {
   ActivityIndicator,
   EdgeInsetsPropType,
@@ -29,7 +30,6 @@ var {
   Text,
   View,
   ViewPropTypes,
-  WebView,
   requireNativeComponent,
   UIManager,
   NativeModules: {

--- a/webview-bridge/index.ios.js
+++ b/webview-bridge/index.ios.js
@@ -119,7 +119,7 @@ var WebViewBridge = createReactClass({
     };
   },
 
-  componentWillMount: function() {
+  componentDidMount: function() {
     if (this.props.startInLoadingState) {
       this.setState({viewState: WebViewBridgeState.LOADING});
     }


### PR DESCRIPTION
Since webview has been removed from RN v0.6, I made the following changes:
- Update webview reference to react-native-webview & add as peer dependency
- Add .podspec file for native module integration